### PR TITLE
Add packages/nomad-FAIR to extraPaths in VScode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./packages/nomad-FAIR"
+    ]
+}


### PR DESCRIPTION
Added a settings.json in the .vscode folder with `python.analysis.extraPaths` pointing to `packages/nomad-FAIR` to provide syntax highlighting in VScode.