### PR TITLE
Remove submodule command from setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ required-version = ">=0.5.14"
 submodule = "git submodule update --init --recursive"
 docker = "docker compose up -d"
 start = "nomad admin run appworker"
-setup = ["submodule", "gui-env", "gui-setup", "docker"]
+setup = ["gui-env", "gui-setup", "docker"]
 lint = ["ruff-lint", "ruff-format"]
 
 [tool.poe.tasks.gui-env]


### PR DESCRIPTION
Remove submodule update in the setup command, the setup command can be then run without having to commit any files.

Running the setup command will also not revert any changes due to submodule updates. 