### PR TITLE
bump elasticsearch heap limit to 1 GB

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.27
     container_name: nomad_elastic
     environment:
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms512m -Xmx1g
       - cluster.routing.allocation.disk.threshold_enabled=true
       - cluster.routing.allocation.disk.watermark.flood_stage=1gb
       - cluster.routing.allocation.disk.watermark.low=4gb


### PR DESCRIPTION
Fix the following unit test error on macos:


```
E       elasticsearch.exceptions.TransportError: TransportError(429, 'search_phase_execution_exception', '[request] Data too large, data for [preallocate[aggregations]] would be [639283200/609.6mb], which is larger than the limit of [322122547/307.1mb]')

../../.venv/lib/python3.12/site-packages/elasticsearch/connection/base.py:328: TransportError
==================================================== short test summary info =====================================================
FAILED tests/app/v1/routers/test_entries.py::test_entries_all_metrics - elasticsearch.exceptions.TransportError: TransportError(429, 'search_phase_execution_exception', '[request] Data too large, d...
```