### PR TITLE
replace deprecated `uv.dev-dependencies`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,11 @@ nomad-external-eln-integrations = { git = "https://github.com/FAIRmat-NFDI/nomad
 extra-index-url = [
   "https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple",
 ]
-dev-dependencies = [
-  "nomad-lab[parsing, infrastructure, dev]>=1.3.4",
-  "poethepoet>=0.29.0",
-]
 constraint-dependencies = ["hyperspy>=1.7.6"]
 required-version = ">=0.5.14"
+
+[dependency-groups]
+dev = ["nomad-lab[parsing, infrastructure, dev]>=1.3.4", "poethepoet>=0.29.0"]
 
 [tool.poe.tasks]
 submodule = "git submodule update --init --recursive"


### PR DESCRIPTION
Fix:
```
warning: The `tool.uv.dev-dependencies` field (used in `/Users/yang/nomad/nomad-distro-dev/pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
```