### PR TITLE
Remove version constraint for `hyperspy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ nomad-external-eln-integrations = { git = "https://github.com/FAIRmat-NFDI/nomad
 extra-index-url = [
   "https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple",
 ]
-constraint-dependencies = ["hyperspy>=1.7.6"]
 required-version = ">=0.5.14"
 
 [dependency-groups]


### PR DESCRIPTION
Looks like [pynxtools-em](https://github.com/search?q=org%3AFAIRmat-NFDI+hyperspy+language%3ATOML&type=code&l=TOML) already has a version constraint for `hyperspy` (I didn't see hyperspy being used elsewhere), so likely it's safe to drop this from `nomad-distro-dev` side?


- [ ] https://github.com/FAIRmat-NFDI/nomad-distro-template/blob/main/pyproject.toml#L72