### PR TITLE
dependencies version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ extra-index-url = [
   "https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple",
 ]
 required-version = ">=0.5.14"
-extra-build-dependencies = { flatdict = ["setuptools<82.0.0"] }
+
+constraint-dependencies = ["optimade<1.1"]
 
 [dependency-groups]
 dev = ["nomad-lab[infrastructure, dev]>=1.3.4", "poethepoet>=0.29.0"]


### PR DESCRIPTION
i get errs for version issues:
```
 Error: Exit code 1
       × Failed to build `flatdict==4.0.1`
       ├─▶ The build backend returned an error
       ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
           status: 1)

           [stderr]
           Traceback (most recent call last):
             File "<string>", line 14, in <module>
             File
           
```
and 
```
TypeError: Cannot read properties of undefined
  (reading 'replace')
  Module.<anonymous>
  src/config.js:94
    91 | window.nomadEnv = window.nomadEnv || {}
    92 | export const version = window.nomadEnv.version
    93 | export const description =
  window.nomadEnv.description
  > 94 | export const appBase =
  urlAbs(window.nomadEnv.appBase.replace(/\/$/, ''))
    95 | export const apiBase = `${appBase}/api`
    96 | export const northBase =
  urlAbs(window.nomadEnv.northBase)
    97 | export const guiBase = process.env.PUBLIC_URL
  View compiled
  ./src/config.js
  http://localhost:3000/nomad-oasis/gui/static/js/main.
  chunk.js:118554:30
  __webpack_require__
  /Users/yaruwang/fairmat/nomad-distro-dev/packages/nom
  ad-FAIR/gui/webpack/bootstrap:851
    848 |
    849 | __webpack_require__.$Refresh$.init();
    850 | try {
  > 851 |     modules[moduleId].call(module.exports,
  module, module.exports, hotCreateRequire(moduleId));
        | ^  852 | } finally {
    853 |
  __webpack_require__.$Refresh$.cleanup(moduleId);
    854 | }
  View compiled
  ```
            