### PR TITLE
Update pyproject for poe gui tasks to work with windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Below are instructions for how to create a dev environment for developing [nomad
 
 3. Install [node.js](https://nodejs.org/en) (v20) and [yarn](https://classic.yarnpkg.com/en/docs/install/)(v1.22). We will use it to setup the GUI.
 
-4. For Windows users, nomad-lab processing doesn't work natively on the platform. We highly recommend using the [Devcontainer](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) plugin in VSCode to run the repository within a container, or alternatively, using [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/about) (WSL) to run the project.
+4. For Windows users, nomad-distro-dev currently works within the platform without WSL/Devcontainers. However, some plugins might not function correctly with Windows.
 
 5. Clone the forked repository.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Below are instructions for how to create a dev environment for developing [nomad
 
 3. Install [node.js](https://nodejs.org/en) (v20) and [yarn](https://classic.yarnpkg.com/en/docs/install/)(v1.22). We will use it to setup the GUI.
 
-4. For Windows users, nomad-distro-dev currently works with the platform without the need for WSL/Devcontainers. However, some NOMAD plugins might not function correctly with Windows.
+4. For Windows users, nomad-distro-dev works natively on Windows. However, not all NOMAD plugins are tested on Windows, so there might be some bugs. If you face any issues, please file an issue in the respective plugin repository.
 
 5. Clone the forked repository.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Below are instructions for how to create a dev environment for developing [nomad
 
 3. Install [node.js](https://nodejs.org/en) (v20) and [yarn](https://classic.yarnpkg.com/en/docs/install/)(v1.22). We will use it to setup the GUI.
 
-4. For Windows users, nomad-distro-dev currently works within the platform without WSL/Devcontainers. However, some plugins might not function correctly with Windows.
+4. For Windows users, nomad-distro-dev currently works with the platform without the need for WSL/Devcontainers. However, some NOMAD plugins might not function correctly with Windows.
 
 5. Clone the forked repository.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ version = "0.1"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
-dependencies = ["nomad-lab[infrastructure]>=1.3.10"]
+dependencies = [
+  "nomad-lab[infrastructure]>=1.3.10",
+  # "nomad-gui==2.0.0a2.dev583",
+]
 
 [tool.uv.workspace]
 members = ["packages/*"]
@@ -73,10 +76,26 @@ cmd = "nomad admin run hub"
 cwd = "packages/nomad-FAIR"
 
 [tool.poe.tasks.gui]
-cmd = "yarn run"
+control.expr = "sys.platform"
+
+[[tool.poe.tasks.gui.switch]]
+case = "win32"
+cmd = "yarn.cmd run start"
+cwd = "packages/nomad-FAIR/gui"
+
+[[tool.poe.tasks.gui.switch]]
+cmd = "yarn run start"
 cwd = "packages/nomad-FAIR/gui"
 
 [tool.poe.tasks.gui-setup]
+control.expr = "sys.platform"
+
+[[tool.poe.tasks.gui-setup.switch]]
+case = "win32"
+cmd = "yarn.cmd"
+cwd = "packages/nomad-FAIR/gui"
+
+[[tool.poe.tasks.gui-setup.switch]]
 cmd = "yarn"
 cwd = "packages/nomad-FAIR/gui"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ version = "0.1"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
-dependencies = [
-  "nomad-lab[infrastructure]>=1.3.10",
-  # "nomad-gui==2.0.0a2.dev583",
-]
+dependencies = ["nomad-lab[infrastructure]>=1.3.10"]
 
 [tool.uv.workspace]
 members = ["packages/*"]


### PR DESCRIPTION
When running in windows, `yarn` seems to be not picked up by poe and has to be replaced with `yarn.cmd`.

Tested with Win11 25H2, poe version 0.48.8